### PR TITLE
Improve audio quality

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "is-ip": "^3.1.0"
   },
   "devDependencies": {
+    "@types/dom-mediacapture-record": "^1.0.7",
     "esbuild": "0.12.3",
     "npm-run-all": "^4.1.5",
     "ts-node": "^10.0.0",

--- a/client/src/transmitter/index.ts
+++ b/client/src/transmitter/index.ts
@@ -67,6 +67,7 @@ function initMimeType() {
     'video/webm;codecs=vp8',
     'video/webm;codecs=daala',
     'video/mpeg',
+    'video/mp4',
   ]
 
   for (const type of types) {

--- a/client/src/transmitter/index.ts
+++ b/client/src/transmitter/index.ts
@@ -263,7 +263,10 @@ async function set_media_to_user(): Promise<MediaStream> {
 
   return new Promise((resolve, reject) => {
     navigator.mediaDevices
-      .getUserMedia({ video: true, audio: true })
+      .getUserMedia({
+        video: true,
+        audio: { echoCancellation: true, noiseSuppression: true },
+      })
       .then((stream) => {
         set_video_stream(stream)
         resolve(stream)
@@ -282,6 +285,7 @@ function setup_media_recorder(stream: MediaStream): void {
 
   media_recorder = new MediaRecorder(stream, {
     mimeType: _mimeType,
+    audioBitsPerSecond: 128 * 1024,
     videoBitsPerSecond: 3 * 1024 * 1024,
   })
 

--- a/client/src/transmitter/index.ts
+++ b/client/src/transmitter/index.ts
@@ -56,7 +56,6 @@ let _streamKey: string | undefined
 let _mimeType: string | undefined
 
 function initMimeType() {
-  // @ts-ignore
   if (!window.MediaRecorder) {
     return
   }
@@ -71,7 +70,6 @@ function initMimeType() {
   ]
 
   for (const type of types) {
-    // @ts-ignore
     const supported = MediaRecorder.isTypeSupported(type)
     if (supported) {
       _mimeType = type
@@ -162,7 +160,6 @@ const minRetryThreshold = 60 * 1000 // 1 min
 
 function start_recording(stream: MediaStream) {
   // console.log('start_recording', stream)
-  // @ts-ignore
   if (recording || !window.MediaRecorder || !_mimeType || !_streamKey) return
 
   recording = true
@@ -283,7 +280,6 @@ function setup_media_recorder(stream: MediaStream): void {
     plunk_media_recorder_listener()
   }
 
-  // @ts-ignore
   media_recorder = new MediaRecorder(stream, {
     mimeType: _mimeType,
     videoBitsPerSecond: 3 * 1024 * 1024,

--- a/client/src/transmitter/index.ts
+++ b/client/src/transmitter/index.ts
@@ -113,7 +113,8 @@ function connect(
 
   const protocol = !localhost && secure ? 'wss' : 'ws'
   const portStr = localhost ? `:${port}` : ''
-  const url = `${protocol}://${hostname}${portStr}/ingest/ws/${_streamKey}?mimeType=${_mimeType}`
+  const query = _mimeType ? `?mimeType=${_mimeType}` : ''
+  const url = `${protocol}://${hostname}${portStr}/ingest/ws/${_streamKey}${query}`
 
   console.log('socket', 'url', url)
 
@@ -161,7 +162,7 @@ const minRetryThreshold = 60 * 1000 // 1 min
 
 function start_recording(stream: MediaStream) {
   // console.log('start_recording', stream)
-  if (recording || !window.MediaRecorder || !_mimeType || !_streamKey) return
+  if (recording || !window.MediaRecorder || !_streamKey) return
 
   recording = true
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -14,12 +14,12 @@
     "noUnusedParameters": false,
     "noImplicitAny": false,
     "declaration": true,
-    "typeRoots": ["node_modules/@types"],
+    "typeRoots": ["node_modules/@types", "../node_modules/@types"],
     "resolveJsonModule": true
   },
   "typeAcquisition": {
     "enable": false
   },
-  "include": ["./src/**/*.ts"],
+  "include": ["../node_modules/@types", "./src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/server/src/clients/ffmpeg.ts
+++ b/server/src/clients/ffmpeg.ts
@@ -10,7 +10,8 @@ const logger = {
     console.error(`[${logTs()}][stream-${streamId}] ${msg}`),
 }
 
-const baseArgs = ['-i', '-', '-acodec', 'aac', '-f', 'flv']
+const audioArgs = ['-acodec', 'aac', '-b:a', '128k', '-ar', '44100']
+const baseArgs = ['-i', '-', '-f', 'flv', ...audioArgs]
 
 const videoCopyArgs = [...baseArgs, '-vcodec', 'copy']
 const videoTranscodeArgs = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,6 +146,11 @@
   dependencies:
     "@types/express" "*"
 
+"@types/dom-mediacapture-record@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.7.tgz#08bacca4296ef521d59049f43e65cf971bbf6be1"
+  integrity sha512-ddDIRTO1ajtbxaNo2o7fPJggpN54PZf1ZUJKOjto2ENMJE/9GKUvaw3ZRuQzlS/p0E+PnIcssxfoqYJ4yiXSBw==
+
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.20.tgz#44caee029f2c26c46711da5e845cdc12167ad72d"


### PR DESCRIPTION
This should close #7 as much as possible, since apparently there's no real echo cancellation on
most browsers, only some primordial logic to avoid reverberation with audio received exclusively
via WebRTC, for peer-to-peer calling. Ref: webrtc/samples#1243

Echo cancellation is still working on Safari on MacOS, but there's not much we can do apart
from that.

Also improved audio quality overall to see if the glitches improve anyway.